### PR TITLE
Fix issue with coercion of 0 values to Timestamp

### DIFF
--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -88,16 +88,10 @@ export function convertValueToTimestampOrGeoPointIfPossible(
     return firestoreStatics.FieldValue.delete();
   }
   /* eslint-enable no-underscore-dangle */
-  if (
-    typeof (dataVal && dataVal.seconds) === 'number' &&
-    typeof (dataVal && dataVal.nanoseconds) === 'number'
-  ) {
+  if (typeof dataVal !== 'undefined' && typeof dataVal.seconds === 'number' && typeof dataVal.nanoseconds === 'number') {
     return new firestoreStatics.Timestamp(dataVal.seconds, dataVal.nanoseconds);
   }
-  if (
-    typeof (dataVal && dataVal.latitude) === 'number' &&
-    typeof (dataVal && dataVal.longitude) === 'number'
-  ) {
+  if (typeof dataVal !== 'undefined' && typeof dataVal.latitude === 'number' && typeof dataVal.longitude === 'number') {
     return new firestoreStatics.GeoPoint(dataVal.latitude, dataVal.longitude);
   }
 


### PR DESCRIPTION
### Description
If a field has the literal value 0, this method will try to coerce it to a Timestamp, which is invalid. E.g:

`cy.callFirestore("set", "examples/example1", { val: 0 })`

This will lead to an error:

```
taskcallFirestore, Object{3}
(uncaught exception)CypressError: cy.task('callFirestore') failed with the following error:

> Value for argument "seconds" is not a valid integer.
```

This is because the expression `dataVal && dataVal.seconds` evaluates to 0 when dataVal is 0, as 0 is falsy:

```
// Run in any javascript console
const dataVal = 0;
typeof (dataVal && dataVal.seconds) === 'number';
-> true
```

I initially went with:

```
if (
    typeof (dataVal?.seconds) === 'number' &&
    typeof (dataVal?.nanoseconds) === 'number'
  ) {
    return new firestoreStatics.Timestamp(dataVal.seconds, dataVal.nanoseconds);
  }
  if (
    typeof (dataVal?.latitude) === 'number' &&
    typeof (dataVal?.longitude) === 'number'
  ) {
    return new firestoreStatics.GeoPoint(dataVal.latitude, dataVal.longitude);
  }
```

... But this causes webpack issues for me, so went with a more verbose but safer option.